### PR TITLE
Add GIN index to text field

### DIFF
--- a/iac/database.sh
+++ b/iac/database.sh
@@ -40,6 +40,9 @@ sql "CREATE INDEX IF NOT EXISTS bedrock_kb_index ON
   );
 " $USER
 
+# Add the GIN index for the text field
+sql "CREATE INDEX ON ${SCHEMA}.${TABLE} USING gin (to_tsvector('simple', ${TEXT}));" $USER
+
 ###############################################################
 # application SCHEMA
 ###############################################################


### PR DESCRIPTION
*Issue #, if available:*
Saw the following error when deploying via terraform:

Error: creating Bedrock Agent Knowledge Base
  with aws_bedrockagent_knowledge_base.main,
  on kb.tf line 5, in resource "aws_bedrockagent_knowledge_base" "main":
   5: resource "aws_bedrockagent_knowledge_base" "main" {

operation error Bedrock Agent: CreateKnowledgeBase, https response error StatusCode: 400, RequestID: <id>, 

ValidationException: The knowledge base storage configuration provided is invalid... chunks column must be indexed. The SQL command to index the column is:  CREATE INDEX ON <table_name> USING gin (to_tsvector('simple', <text_field>));

*Description of changes:*

Add SQL statement to create a GIN index for the text field in the database.sh file.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
