### PR TITLE
Update embedded model

### DIFF
--- a/iac/kb.tf
+++ b/iac/kb.tf
@@ -1,5 +1,5 @@
 locals {
-  embedding_model_arn = "arn:aws:bedrock:${local.region}::foundation-model/amazon.titan-embed-g1-text-02"
+  embedding_model_arn = "arn:aws:bedrock:${local.region}::foundation-model/amazon.titan-embed-text-v1"
 }
 
 resource "aws_bedrockagent_knowledge_base" "main" {

--- a/iac/kb.tf
+++ b/iac/kb.tf
@@ -1,5 +1,5 @@
 locals {
-  embedding_model_arn = "arn:aws:bedrock:${local.region}::foundation-model/amazon.titan-embed-text-v1"
+  embedding_model_arn = "arn:aws:bedrock:${local.region}::foundation-model/amazon.titan-embed-text-v2:0"
 }
 
 resource "aws_bedrockagent_knowledge_base" "main" {


### PR DESCRIPTION
*Issue #, if available:*
I wasn't able to find and enable the amazon.titan-embed-g1-text-02 model in the AWS bedrock console.

*Description of changes:*
Change to the amazon.titan-embed-text-v1 model.

I was able to get amazon.titan-embed-text-v1 enabled in the AWS bedrock console and was able to get the chat bot functional using this model.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
